### PR TITLE
Revert "Update README.md"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ ixset [![Hackage](https://img.shields.io/hackage/v/ixset.svg)](https://hackage.h
 
 Create and query sets that are indexed by multiple indices.
 
-For more documentation see [this section](http://happstack.com/docs/crashcourse/AcidState.html#ixset) of The Happstack Book.
+For more documentation see [this section](http://www.happstack.com/docs/crashcourse/index.html#ixset-a-set-with-multiple-indexed-keys) of The Happstack Book.


### PR DESCRIPTION
Reverts Happstack/ixset#5

Turns out the README.md had the correct URL and that an old version of the Happstack Book had gotten uploaded. 